### PR TITLE
Skip prom validation for SLOs

### DIFF
--- a/src/prometheus/model.go
+++ b/src/prometheus/model.go
@@ -33,8 +33,8 @@ type SLIEvents struct {
 type AlertMeta struct {
 	Disable     bool
 	Name        string            `validate:"required_if_enabled"`
-	Labels      map[string]string `validate:"dive,keys,prom_label_key,endkeys,required,prom_label_value"`
-	Annotations map[string]string `validate:"dive,keys,prom_annot_key,endkeys,required"`
+	Labels      map[string]string `validate:"dive,keys,endkeys,required"`
+	Annotations map[string]string `validate:"dive,keys,endkeys,required"`
 }
 
 // SLO represents a service level objective configuration.
@@ -46,7 +46,7 @@ type SLO struct {
 	SLI             SLI               `validate:"required"`
 	TimeWindow      time.Duration     `validate:"required"`
 	Objective       float64           `validate:"gt=0,lte=100"`
-	Labels          map[string]string `validate:"dive,keys,prom_label_key,endkeys,required,prom_label_value"`
+	Labels          map[string]string `validate:"dive,keys,endkeys,required"`
 	PageAlertMeta   AlertMeta
 	TicketAlertMeta AlertMeta
 }
@@ -80,9 +80,6 @@ var modelSpecValidate = func() *validator.Validate {
 
 	// More information on prometheus validators logic: https://github.com/prometheus/prometheus/blob/df80dc4d3970121f2f76cba79050983ffb3cdbb0/pkg/rulefmt/rulefmt.go#L188-L208
 	mustRegisterValidation(v, "prom_expr", validatePromExpression)
-	mustRegisterValidation(v, "prom_label_key", validatePromLabelKey)
-	mustRegisterValidation(v, "prom_label_value", validatePromLabelValue)
-	mustRegisterValidation(v, "prom_annot_key", validatePromAnnotKey)
 	mustRegisterValidation(v, "name", validateName)
 	mustRegisterValidation(v, "required_if_enabled", validateRequiredEnabledAlertName)
 	mustRegisterValidation(v, "template_vars", validateTemplateVars)

--- a/src/prometheus/model_test.go
+++ b/src/prometheus/model_test.go
@@ -289,15 +289,6 @@ func TestModelValidationSpec(t *testing.T) {
 			expErrMessage: "Key: 'SLOGroup.SLOs[0].Objective' Error:Field validation for 'Objective' failed on the 'lte' tag",
 		},
 
-		"SLO Labels should be valid prometheus keys.": {
-			slo: func() prometheus.SLOGroup {
-				s := getGoodSLOGroup()
-				s.SLOs[0].Labels[".something"] = "label key is wrong"
-				return s
-			},
-			expErrMessage: "Key: 'SLOGroup.SLOs[0].Labels[.something]' Error:Field validation for 'Labels[.something]' failed on the 'prom_label_key' tag",
-		},
-
 		"SLO Labels should have prometheus values.": {
 			slo: func() prometheus.SLOGroup {
 				s := getGoodSLOGroup()
@@ -305,15 +296,6 @@ func TestModelValidationSpec(t *testing.T) {
 				return s
 			},
 			expErrMessage: "Key: 'SLOGroup.SLOs[0].Labels[something]' Error:Field validation for 'Labels[something]' failed on the 'required' tag",
-		},
-
-		"SLO Labels should be valid prometheus values.": {
-			slo: func() prometheus.SLOGroup {
-				s := getGoodSLOGroup()
-				s.SLOs[0].Labels["something"] = "\xc3\x28"
-				return s
-			},
-			expErrMessage: "Key: 'SLOGroup.SLOs[0].Labels[something]' Error:Field validation for 'Labels[something]' failed on the 'prom_label_value' tag",
 		},
 
 		"SLO page alert name is required.": {
@@ -356,15 +338,6 @@ func TestModelValidationSpec(t *testing.T) {
 			},
 		},
 
-		"SLO page alert labels should be valid prometheus keys.": {
-			slo: func() prometheus.SLOGroup {
-				s := getGoodSLOGroup()
-				s.SLOs[0].PageAlertMeta.Labels[".something"] = "label key is wrong"
-				return s
-			},
-			expErrMessage: "Key: 'SLOGroup.SLOs[0].PageAlertMeta.Labels[.something]' Error:Field validation for 'Labels[.something]' failed on the 'prom_label_key' tag",
-		},
-
 		"SLO page alert labels should have prometheus values.": {
 			slo: func() prometheus.SLOGroup {
 				s := getGoodSLOGroup()
@@ -372,24 +345,6 @@ func TestModelValidationSpec(t *testing.T) {
 				return s
 			},
 			expErrMessage: "Key: 'SLOGroup.SLOs[0].PageAlertMeta.Labels[something]' Error:Field validation for 'Labels[something]' failed on the 'required' tag",
-		},
-
-		"SLO page alert labels should be valid prometheus values.": {
-			slo: func() prometheus.SLOGroup {
-				s := getGoodSLOGroup()
-				s.SLOs[0].PageAlertMeta.Labels["something"] = "\xc3\x28"
-				return s
-			},
-			expErrMessage: "Key: 'SLOGroup.SLOs[0].PageAlertMeta.Labels[something]' Error:Field validation for 'Labels[something]' failed on the 'prom_label_value' tag",
-		},
-
-		"SLO page alert annotations should be valid prometheus keys.": {
-			slo: func() prometheus.SLOGroup {
-				s := getGoodSLOGroup()
-				s.SLOs[0].PageAlertMeta.Annotations[".something"] = "label key is wrong"
-				return s
-			},
-			expErrMessage: "Key: 'SLOGroup.SLOs[0].PageAlertMeta.Annotations[.something]' Error:Field validation for 'Annotations[.something]' failed on the 'prom_annot_key' tag",
 		},
 
 		"SLO page alert annotations should have prometheus values.": {
@@ -401,15 +356,6 @@ func TestModelValidationSpec(t *testing.T) {
 			expErrMessage: "Key: 'SLOGroup.SLOs[0].PageAlertMeta.Annotations[something]' Error:Field validation for 'Annotations[something]' failed on the 'required' tag",
 		},
 
-		"SLO warning alert labels should be valid prometheus keys.": {
-			slo: func() prometheus.SLOGroup {
-				s := getGoodSLOGroup()
-				s.SLOs[0].TicketAlertMeta.Labels[".something"] = "label key is wrong"
-				return s
-			},
-			expErrMessage: "Key: 'SLOGroup.SLOs[0].TicketAlertMeta.Labels[.something]' Error:Field validation for 'Labels[.something]' failed on the 'prom_label_key' tag",
-		},
-
 		"SLO warning alert labels should have prometheus values.": {
 			slo: func() prometheus.SLOGroup {
 				s := getGoodSLOGroup()
@@ -417,24 +363,6 @@ func TestModelValidationSpec(t *testing.T) {
 				return s
 			},
 			expErrMessage: "Key: 'SLOGroup.SLOs[0].TicketAlertMeta.Labels[something]' Error:Field validation for 'Labels[something]' failed on the 'required' tag",
-		},
-
-		"SLO warning alert labels should be valid prometheus values.": {
-			slo: func() prometheus.SLOGroup {
-				s := getGoodSLOGroup()
-				s.SLOs[0].TicketAlertMeta.Labels["something"] = "\xc3\x28"
-				return s
-			},
-			expErrMessage: "Key: 'SLOGroup.SLOs[0].TicketAlertMeta.Labels[something]' Error:Field validation for 'Labels[something]' failed on the 'prom_label_value' tag",
-		},
-
-		"SLO warning alert annotations should be valid prometheus keys.": {
-			slo: func() prometheus.SLOGroup {
-				s := getGoodSLOGroup()
-				s.SLOs[0].TicketAlertMeta.Annotations[".something"] = "label key is wrong"
-				return s
-			},
-			expErrMessage: "Key: 'SLOGroup.SLOs[0].TicketAlertMeta.Annotations[.something]' Error:Field validation for 'Annotations[.something]' failed on the 'prom_annot_key' tag",
 		},
 
 		"SLO warning alert annotations should have prometheus values.": {


### PR DESCRIPTION
Since we aren't installing in prom , don't validate that alert labels are prom compliant